### PR TITLE
updated IRIs to Credit Ontology IRIs, and added some additional synonyms

### DIFF
--- a/src/ontology/cro-edit.owl
+++ b/src/ontology/cro-edit.owl
@@ -179,14 +179,14 @@ AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibra
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CREDIT_00000007> "project administration role")
 SubClassOf(<http://purl.obolibrary.org/obo/CREDIT_00000007> <http://purl.obolibrary.org/obo/CRO_00000000>)
 
-# Class: <http://purl.obolibrary.org/obo/CREDIT_00000008> (resource provider role)
+# Class: <http://purl.obolibrary.org/obo/CREDIT_00000008> (resources role)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/CREDIT_00000008> "Provision of study materials, reagents, materials, patients, laboratory samples, animals, instrumentation, computing resources, or other analysis tools.")
-AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <http://purl.obolibrary.org/obo/CREDIT_00000008> "resources role")
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <http://purl.obolibrary.org/obo/CREDIT_00000008> "resource provider role")
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000119> <http://purl.obolibrary.org/obo/CREDIT_00000008> "http://dictionary.casrai.org/Contributor_Roles/Resources")
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> <http://purl.obolibrary.org/obo/CREDIT_00000008> <http://orcid.org/0000-0001-5208-3432>)
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibrary.org/obo/CREDIT_00000008> "2018-09-14T20:06:06Z"^^xsd:dateTime)
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CREDIT_00000008> "resource provider role")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CREDIT_00000008> "resources role")
 SubClassOf(<http://purl.obolibrary.org/obo/CREDIT_00000008> <http://purl.obolibrary.org/obo/CRO_00000000>)
 
 # Class: <http://purl.obolibrary.org/obo/CREDIT_00000009> (software developer role)

--- a/src/ontology/cro-edit.owl
+++ b/src/ontology/cro-edit.owl
@@ -11,12 +11,24 @@ Import(<http://purl.obolibrary.org/obo/cro/imports/bfo_import.owl>)
 Import(<http://purl.obolibrary.org/obo/cro/imports/iao_import.owl>)
 Annotation(rdfs:comment "Contributor Role Ontology")
 
+Declaration(Class(<http://purl.obolibrary.org/obo/CREDIT_00000001>))
+Declaration(Class(<http://purl.obolibrary.org/obo/CREDIT_00000002>))
+Declaration(Class(<http://purl.obolibrary.org/obo/CREDIT_00000003>))
+Declaration(Class(<http://purl.obolibrary.org/obo/CREDIT_00000004>))
+Declaration(Class(<http://purl.obolibrary.org/obo/CREDIT_00000005>))
+Declaration(Class(<http://purl.obolibrary.org/obo/CREDIT_00000006>))
+Declaration(Class(<http://purl.obolibrary.org/obo/CREDIT_00000007>))
+Declaration(Class(<http://purl.obolibrary.org/obo/CREDIT_00000008>))
+Declaration(Class(<http://purl.obolibrary.org/obo/CREDIT_00000009>))
+Declaration(Class(<http://purl.obolibrary.org/obo/CREDIT_00000010>))
+Declaration(Class(<http://purl.obolibrary.org/obo/CREDIT_00000011>))
+Declaration(Class(<http://purl.obolibrary.org/obo/CREDIT_00000012>))
+Declaration(Class(<http://purl.obolibrary.org/obo/CREDIT_00000013>))
+Declaration(Class(<http://purl.obolibrary.org/obo/CREDIT_00000014>))
 Declaration(Class(<http://purl.obolibrary.org/obo/CRO_00000000>))
 Declaration(Class(<http://purl.obolibrary.org/obo/CRO_0000001>))
-Declaration(Class(<http://purl.obolibrary.org/obo/CRO_0000002>))
 Declaration(Class(<http://purl.obolibrary.org/obo/CRO_0000003>))
 Declaration(Class(<http://purl.obolibrary.org/obo/CRO_0000004>))
-Declaration(Class(<http://purl.obolibrary.org/obo/CRO_0000005>))
 Declaration(Class(<http://purl.obolibrary.org/obo/CRO_0000006>))
 Declaration(Class(<http://purl.obolibrary.org/obo/CRO_0000007>))
 Declaration(Class(<http://purl.obolibrary.org/obo/CRO_0000008>))
@@ -24,38 +36,26 @@ Declaration(Class(<http://purl.obolibrary.org/obo/CRO_0000009>))
 Declaration(Class(<http://purl.obolibrary.org/obo/CRO_0000010>))
 Declaration(Class(<http://purl.obolibrary.org/obo/CRO_0000011>))
 Declaration(Class(<http://purl.obolibrary.org/obo/CRO_0000012>))
-Declaration(Class(<http://purl.obolibrary.org/obo/CRO_0000013>))
 Declaration(Class(<http://purl.obolibrary.org/obo/CRO_0000014>))
 Declaration(Class(<http://purl.obolibrary.org/obo/CRO_0000015>))
 Declaration(Class(<http://purl.obolibrary.org/obo/CRO_0000016>))
-Declaration(Class(<http://purl.obolibrary.org/obo/CRO_0000017>))
 Declaration(Class(<http://purl.obolibrary.org/obo/CRO_0000018>))
 Declaration(Class(<http://purl.obolibrary.org/obo/CRO_0000019>))
 Declaration(Class(<http://purl.obolibrary.org/obo/CRO_0000020>))
-Declaration(Class(<http://purl.obolibrary.org/obo/CRO_0000021>))
 Declaration(Class(<http://purl.obolibrary.org/obo/CRO_0000022>))
 Declaration(Class(<http://purl.obolibrary.org/obo/CRO_0000023>))
-Declaration(Class(<http://purl.obolibrary.org/obo/CRO_0000024>))
 Declaration(Class(<http://purl.obolibrary.org/obo/CRO_0000025>))
 Declaration(Class(<http://purl.obolibrary.org/obo/CRO_0000026>))
-Declaration(Class(<http://purl.obolibrary.org/obo/CRO_0000027>))
-Declaration(Class(<http://purl.obolibrary.org/obo/CRO_0000028>))
-Declaration(Class(<http://purl.obolibrary.org/obo/CRO_0000029>))
-Declaration(Class(<http://purl.obolibrary.org/obo/CRO_0000030>))
 Declaration(Class(<http://purl.obolibrary.org/obo/CRO_0000031>))
-Declaration(Class(<http://purl.obolibrary.org/obo/CRO_0000032>))
 Declaration(Class(<http://purl.obolibrary.org/obo/CRO_0000033>))
-Declaration(Class(<http://purl.obolibrary.org/obo/CRO_0000034>))
 Declaration(Class(<http://purl.obolibrary.org/obo/CRO_0000035>))
 Declaration(Class(<http://purl.obolibrary.org/obo/CRO_0000036>))
-Declaration(Class(<http://purl.obolibrary.org/obo/CRO_0000037>))
 Declaration(Class(<http://purl.obolibrary.org/obo/CRO_0000038>))
 Declaration(Class(<http://purl.obolibrary.org/obo/CRO_0000039>))
 Declaration(Class(<http://purl.obolibrary.org/obo/CRO_0000040>))
 Declaration(Class(<http://purl.obolibrary.org/obo/CRO_0000041>))
 Declaration(Class(<http://purl.obolibrary.org/obo/CRO_0000042>))
 Declaration(Class(<http://purl.obolibrary.org/obo/CRO_0000043>))
-Declaration(Class(<http://purl.obolibrary.org/obo/CRO_0000044>))
 Declaration(Class(<http://purl.obolibrary.org/obo/CRO_0000045>))
 Declaration(Class(<http://purl.obolibrary.org/obo/CRO_0000046>))
 Declaration(Class(<http://purl.obolibrary.org/obo/CRO_0000047>))
@@ -109,6 +109,143 @@ Declaration(AnnotationProperty(<http://purl.org/dc/elements/1.1/date>))
 #   Classes
 ############################
 
+# Class: <http://purl.obolibrary.org/obo/CREDIT_00000001> (conceptualization role)
+
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/CREDIT_00000001> "Ideas; formulation or evolution of overarching research goals and aims.")
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000119> <http://purl.obolibrary.org/obo/CREDIT_00000001> "http://dictionary.casrai.org/Contributor_Roles/Conceptualization")
+AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> <http://purl.obolibrary.org/obo/CREDIT_00000001> <http://orcid.org/0000-0001-5208-3432>)
+AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibrary.org/obo/CREDIT_00000001> "2018-09-14T19:54:15Z"^^xsd:dateTime)
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CREDIT_00000001> "conceptualization role")
+SubClassOf(<http://purl.obolibrary.org/obo/CREDIT_00000001> <http://purl.obolibrary.org/obo/CRO_00000000>)
+
+# Class: <http://purl.obolibrary.org/obo/CREDIT_00000002> (data curation role)
+
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/CREDIT_00000002> "Management activities to annotate (produce metadata), scrub data and maintain research data (including software code, where it is necessary for interpreting the data itself) for initial use and later re-use.")
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <http://purl.obolibrary.org/obo/CREDIT_00000002> "curation role")
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000119> <http://purl.obolibrary.org/obo/CREDIT_00000002> "http://dictionary.casrai.org/Contributor_Roles/Data_curation")
+AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> <http://purl.obolibrary.org/obo/CREDIT_00000002> <http://orcid.org/0000-0001-5208-3432>)
+AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibrary.org/obo/CREDIT_00000002> "2018-09-14T20:11:44Z"^^xsd:dateTime)
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CREDIT_00000002> "data curation role")
+SubClassOf(<http://purl.obolibrary.org/obo/CREDIT_00000002> <http://purl.obolibrary.org/obo/CRO_0000015>)
+
+# Class: <http://purl.obolibrary.org/obo/CREDIT_00000003> (data analysis role)
+
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/CREDIT_00000003> "Preparation, creation and/or presentation of the published work, specifically visualization/data presentation.")
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <http://purl.obolibrary.org/obo/CREDIT_00000003> "formal analysis role")
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <http://purl.obolibrary.org/obo/CREDIT_00000003> "formal data analysis role")
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000119> <http://purl.obolibrary.org/obo/CREDIT_00000003> "http://dictionary.casrai.org/Contributor_Roles/Formal_analysis")
+AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> <http://purl.obolibrary.org/obo/CREDIT_00000003> <http://orcid.org/0000-0001-5208-3432>)
+AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibrary.org/obo/CREDIT_00000003> "2018-09-14T20:11:31Z"^^xsd:dateTime)
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CREDIT_00000003> "data analysis role")
+SubClassOf(<http://purl.obolibrary.org/obo/CREDIT_00000003> <http://purl.obolibrary.org/obo/CRO_0000015>)
+
+# Class: <http://purl.obolibrary.org/obo/CREDIT_00000004> (funding acquisition role)
+
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000119> <http://purl.obolibrary.org/obo/CREDIT_00000004> "http://dictionary.casrai.org/Contributor_Roles/Funding_acquisition")
+AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> <http://purl.obolibrary.org/obo/CREDIT_00000004> <http://orcid.org/0000-0001-5208-3432>)
+AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibrary.org/obo/CREDIT_00000004> "2018-09-14T19:55:54Z"^^xsd:dateTime)
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CREDIT_00000004> "funding acquisition role")
+SubClassOf(<http://purl.obolibrary.org/obo/CREDIT_00000004> <http://purl.obolibrary.org/obo/CRO_00000000>)
+
+# Class: <http://purl.obolibrary.org/obo/CREDIT_00000005> (study investigation role)
+
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/CREDIT_00000005> "Conducting a research and investigation process, specifically performing the experiments, or data/evidence collection.")
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <http://purl.obolibrary.org/obo/CREDIT_00000005> "experimentation role")
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <http://purl.obolibrary.org/obo/CREDIT_00000005> "investigation role")
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000119> <http://purl.obolibrary.org/obo/CREDIT_00000005> "http://dictionary.casrai.org/Contributor_Roles/Investigation")
+AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> <http://purl.obolibrary.org/obo/CREDIT_00000005> <http://orcid.org/0000-0001-5208-3432>)
+AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibrary.org/obo/CREDIT_00000005> "2018-09-14T20:06:17Z"^^xsd:dateTime)
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CREDIT_00000005> "study investigation role")
+SubClassOf(<http://purl.obolibrary.org/obo/CREDIT_00000005> <http://purl.obolibrary.org/obo/CRO_00000000>)
+
+# Class: <http://purl.obolibrary.org/obo/CREDIT_00000006> (methodology role)
+
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/CREDIT_00000006> "Development or design of methodology; creation of models.")
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <http://purl.obolibrary.org/obo/CREDIT_00000006> "methodology development role")
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000119> <http://purl.obolibrary.org/obo/CREDIT_00000006> "http://dictionary.casrai.org/Contributor_Roles/Methodology")
+AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> <http://purl.obolibrary.org/obo/CREDIT_00000006> <http://orcid.org/0000-0001-5208-3432>)
+AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibrary.org/obo/CREDIT_00000006> "2018-09-14T20:04:19Z"^^xsd:dateTime)
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CREDIT_00000006> "methodology role")
+SubClassOf(<http://purl.obolibrary.org/obo/CREDIT_00000006> <http://purl.obolibrary.org/obo/CRO_00000000>)
+
+# Class: <http://purl.obolibrary.org/obo/CREDIT_00000007> (project management role)
+
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/CREDIT_00000007> "Management and coordination responsibility for the research activity planning and execution.")
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <http://purl.obolibrary.org/obo/CREDIT_00000007> "project administration role")
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <http://purl.obolibrary.org/obo/CREDIT_00000007> "project administrator role")
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000119> <http://purl.obolibrary.org/obo/CREDIT_00000007> "http://dictionary.casrai.org/Contributor_Roles/Project_administration")
+AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> <http://purl.obolibrary.org/obo/CREDIT_00000007> <http://orcid.org/0000-0001-5208-3432>)
+AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibrary.org/obo/CREDIT_00000007> "2018-09-14T20:04:49Z"^^xsd:dateTime)
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CREDIT_00000007> "project management role")
+SubClassOf(<http://purl.obolibrary.org/obo/CREDIT_00000007> <http://purl.obolibrary.org/obo/CRO_00000000>)
+
+# Class: <http://purl.obolibrary.org/obo/CREDIT_00000008> (resource provider role)
+
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/CREDIT_00000008> "Provision of study materials, reagents, materials, patients, laboratory samples, animals, instrumentation, computing resources, or other analysis tools.")
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <http://purl.obolibrary.org/obo/CREDIT_00000008> "resources role")
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000119> <http://purl.obolibrary.org/obo/CREDIT_00000008> "http://dictionary.casrai.org/Contributor_Roles/Resources")
+AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> <http://purl.obolibrary.org/obo/CREDIT_00000008> <http://orcid.org/0000-0001-5208-3432>)
+AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibrary.org/obo/CREDIT_00000008> "2018-09-14T20:06:06Z"^^xsd:dateTime)
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CREDIT_00000008> "resource provider role")
+SubClassOf(<http://purl.obolibrary.org/obo/CREDIT_00000008> <http://purl.obolibrary.org/obo/CRO_00000000>)
+
+# Class: <http://purl.obolibrary.org/obo/CREDIT_00000009> (software developer role)
+
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/CREDIT_00000009> "Programming, software development; designing computer programs; implementation of the computer code and supporting algorithms; testing of existing code components.")
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <http://purl.obolibrary.org/obo/CREDIT_00000009> "software role")
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000119> <http://purl.obolibrary.org/obo/CREDIT_00000009> "http://dictionary.casrai.org/Contributor_Roles/Software")
+AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> <http://purl.obolibrary.org/obo/CREDIT_00000009> <http://orcid.org/0000-0001-5208-3432>)
+AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibrary.org/obo/CREDIT_00000009> "2018-09-14T20:06:12Z"^^xsd:dateTime)
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CREDIT_00000009> "software developer role")
+SubClassOf(<http://purl.obolibrary.org/obo/CREDIT_00000009> <http://purl.obolibrary.org/obo/CRO_00000000>)
+
+# Class: <http://purl.obolibrary.org/obo/CREDIT_00000010> (supervision role)
+
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/CREDIT_00000010> "Oversight and leadership responsibility for the research activity planning and execution, including mentorship external to the core team.")
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000119> <http://purl.obolibrary.org/obo/CREDIT_00000010> "http://dictionary.casrai.org/Contributor_Roles/Supervision")
+AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> <http://purl.obolibrary.org/obo/CREDIT_00000010> <http://orcid.org/0000-0001-5208-3432>)
+AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibrary.org/obo/CREDIT_00000010> "2018-09-14T20:06:22Z"^^xsd:dateTime)
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CREDIT_00000010> "supervision role")
+SubClassOf(<http://purl.obolibrary.org/obo/CREDIT_00000010> <http://purl.obolibrary.org/obo/CRO_00000000>)
+
+# Class: <http://purl.obolibrary.org/obo/CREDIT_00000011> (validation role)
+
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/CREDIT_00000011> "Verification, whether as a part of the activity or separate, of the overall replication/reproducibility of results/experiments and other research outputs.")
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000119> <http://purl.obolibrary.org/obo/CREDIT_00000011> "http://dictionary.casrai.org/Contributor_Roles/Validation")
+AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> <http://purl.obolibrary.org/obo/CREDIT_00000011> <http://orcid.org/0000-0001-5208-3432>)
+AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibrary.org/obo/CREDIT_00000011> "2018-09-14T20:06:30Z"^^xsd:dateTime)
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CREDIT_00000011> "validation role")
+SubClassOf(<http://purl.obolibrary.org/obo/CREDIT_00000011> <http://purl.obolibrary.org/obo/CRO_00000000>)
+
+# Class: <http://purl.obolibrary.org/obo/CREDIT_00000012> (data visualization role)
+
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/CREDIT_00000012> "Preparation, creation and/or presentation of the published work, specifically visualization/data presentation.")
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <http://purl.obolibrary.org/obo/CREDIT_00000012> "visualization role")
+AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> <http://purl.obolibrary.org/obo/CREDIT_00000012> <http://orcid.org/0000-0001-5208-3432>)
+AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibrary.org/obo/CREDIT_00000012> "2018-09-14T20:12:30Z"^^xsd:dateTime)
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CREDIT_00000012> "data visualization role")
+SubClassOf(<http://purl.obolibrary.org/obo/CREDIT_00000012> <http://purl.obolibrary.org/obo/CRO_0000015>)
+
+# Class: <http://purl.obolibrary.org/obo/CREDIT_00000013> (writing original draft role)
+
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/CREDIT_00000013> "Preparation, creation and/or presentation of the published work, specifically writing the initial draft.")
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000119> <http://purl.obolibrary.org/obo/CREDIT_00000013> "http://dictionary.casrai.org/Contributor_Roles/Writing_%E2%80%93_original_draft")
+AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> <http://purl.obolibrary.org/obo/CREDIT_00000013> <http://orcid.org/0000-0001-5208-3432>)
+AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibrary.org/obo/CREDIT_00000013> "2018-09-14T19:50:19Z"^^xsd:dateTime)
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CREDIT_00000013> "writing original draft role")
+SubClassOf(<http://purl.obolibrary.org/obo/CREDIT_00000013> <http://purl.obolibrary.org/obo/CRO_0000001>)
+
+# Class: <http://purl.obolibrary.org/obo/CREDIT_00000014> (editing and proofreading role)
+
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/CREDIT_00000014> "Preparation, creation and/or presentation of the published work by those from the original research group, specifically critical review, commentary or revision – including pre- or post-publication stages.")
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <http://purl.obolibrary.org/obo/CREDIT_00000014> "review and editing")
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <http://purl.obolibrary.org/obo/CREDIT_00000014> "writing review and editing role")
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000119> <http://purl.obolibrary.org/obo/CREDIT_00000014> "http://dictionary.casrai.org/Contributor_Roles/Writing_%E2%80%93_review_%26_editing")
+AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> <http://purl.obolibrary.org/obo/CREDIT_00000014> <http://orcid.org/0000-0001-5208-3432>)
+AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibrary.org/obo/CREDIT_00000014> "2018-09-14T19:48:16Z"^^xsd:dateTime)
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CREDIT_00000014> "editing and proofreading role")
+SubClassOf(<http://purl.obolibrary.org/obo/CREDIT_00000014> <http://purl.obolibrary.org/obo/CRO_0000001>)
+
 # Class: <http://purl.obolibrary.org/obo/CRO_00000000> (contributor role)
 
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CRO_00000000> "contributor role"@en)
@@ -116,20 +253,11 @@ AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CRO_00000000> "co
 # Class: <http://purl.obolibrary.org/obo/CRO_0000001> (author role)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/CRO_0000001> "Contributions to the published research object.")
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <http://purl.obolibrary.org/obo/CRO_0000001> "writer role")
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> <http://purl.obolibrary.org/obo/CRO_0000001> <http://orcid.org/0000-0001-5208-3432>)
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibrary.org/obo/CRO_0000001> "2018-09-14T19:47:01Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CRO_0000001> "author role")
 SubClassOf(<http://purl.obolibrary.org/obo/CRO_0000001> <http://purl.obolibrary.org/obo/CRO_00000000>)
-
-# Class: <http://purl.obolibrary.org/obo/CRO_0000002> (editing and proofreading role)
-
-AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/CRO_0000002> "Preparation, creation and/or presentation of the published work by those from the original research group, specifically critical review, commentary or revision – including pre- or post-publication stages.")
-AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <http://purl.obolibrary.org/obo/CRO_0000002> "review and editing")
-AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000119> <http://purl.obolibrary.org/obo/CRO_0000002> "http://dictionary.casrai.org/Contributor_Roles/Writing_%E2%80%93_review_%26_editing")
-AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> <http://purl.obolibrary.org/obo/CRO_0000002> <http://orcid.org/0000-0001-5208-3432>)
-AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibrary.org/obo/CRO_0000002> "2018-09-14T19:48:16Z"^^xsd:dateTime)
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CRO_0000002> "editing and proofreading role")
-SubClassOf(<http://purl.obolibrary.org/obo/CRO_0000002> <http://purl.obolibrary.org/obo/CRO_0000001>)
 
 # Class: <http://purl.obolibrary.org/obo/CRO_0000003> (figure development role)
 
@@ -147,15 +275,6 @@ AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> <http://purl.oboli
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibrary.org/obo/CRO_0000004> "2018-09-14T19:49:51Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CRO_0000004> "translator role")
 SubClassOf(<http://purl.obolibrary.org/obo/CRO_0000004> <http://purl.obolibrary.org/obo/CRO_0000001>)
-
-# Class: <http://purl.obolibrary.org/obo/CRO_0000005> (writing original draft role)
-
-AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/CRO_0000005> "Preparation, creation and/or presentation of the published work, specifically writing the initial draft.")
-AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000119> <http://purl.obolibrary.org/obo/CRO_0000005> "http://dictionary.casrai.org/Contributor_Roles/Writing_%E2%80%93_original_draft")
-AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> <http://purl.obolibrary.org/obo/CRO_0000005> <http://orcid.org/0000-0001-5208-3432>)
-AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibrary.org/obo/CRO_0000005> "2018-09-14T19:50:19Z"^^xsd:dateTime)
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CRO_0000005> "writing original draft role")
-SubClassOf(<http://purl.obolibrary.org/obo/CRO_0000005> <http://purl.obolibrary.org/obo/CRO_0000001>)
 
 # Class: <http://purl.obolibrary.org/obo/CRO_0000006> (background and literature search role)
 
@@ -210,15 +329,6 @@ AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibra
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CRO_0000012> "graphic design role")
 SubClassOf(<http://purl.obolibrary.org/obo/CRO_0000012> <http://purl.obolibrary.org/obo/CRO_0000007>)
 
-# Class: <http://purl.obolibrary.org/obo/CRO_0000013> (conceptualization role)
-
-AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/CRO_0000013> "Ideas; formulation or evolution of overarching research goals and aims.")
-AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000119> <http://purl.obolibrary.org/obo/CRO_0000013> "http://dictionary.casrai.org/Contributor_Roles/Conceptualization")
-AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> <http://purl.obolibrary.org/obo/CRO_0000013> <http://orcid.org/0000-0001-5208-3432>)
-AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibrary.org/obo/CRO_0000013> "2018-09-14T19:54:15Z"^^xsd:dateTime)
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CRO_0000013> "conceptualization role")
-SubClassOf(<http://purl.obolibrary.org/obo/CRO_0000013> <http://purl.obolibrary.org/obo/CRO_00000000>)
-
 # Class: <http://purl.obolibrary.org/obo/CRO_0000014> (technical writing role)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/CRO_0000014> "Creation of software documentation.")
@@ -228,7 +338,7 @@ AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <http://purl.ob
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> <http://purl.obolibrary.org/obo/CRO_0000014> <http://orcid.org/0000-0001-5208-3432>)
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibrary.org/obo/CRO_0000014> "2018-09-14T20:26:05Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CRO_0000014> "technical writing role")
-SubClassOf(<http://purl.obolibrary.org/obo/CRO_0000014> <http://purl.obolibrary.org/obo/CRO_0000028>)
+SubClassOf(<http://purl.obolibrary.org/obo/CRO_0000014> <http://purl.obolibrary.org/obo/CREDIT_00000009>)
 
 # Class: <http://purl.obolibrary.org/obo/CRO_0000015> (data role)
 
@@ -244,14 +354,6 @@ AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibra
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CRO_0000016> "educational role")
 SubClassOf(<http://purl.obolibrary.org/obo/CRO_0000016> <http://purl.obolibrary.org/obo/CRO_00000000>)
 
-# Class: <http://purl.obolibrary.org/obo/CRO_0000017> (funding acquisition role)
-
-AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000119> <http://purl.obolibrary.org/obo/CRO_0000017> "http://dictionary.casrai.org/Contributor_Roles/Funding_acquisition")
-AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> <http://purl.obolibrary.org/obo/CRO_0000017> <http://orcid.org/0000-0001-5208-3432>)
-AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibrary.org/obo/CRO_0000017> "2018-09-14T19:55:54Z"^^xsd:dateTime)
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CRO_0000017> "funding acquisition role")
-SubClassOf(<http://purl.obolibrary.org/obo/CRO_0000017> <http://purl.obolibrary.org/obo/CRO_00000000>)
-
 # Class: <http://purl.obolibrary.org/obo/CRO_0000018> (information technology systems role)
 
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> <http://purl.obolibrary.org/obo/CRO_0000018> <http://orcid.org/0000-0001-5208-3432>)
@@ -266,7 +368,7 @@ AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <http://purl.ob
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> <http://purl.obolibrary.org/obo/CRO_0000019> <http://orcid.org/0000-0001-5208-3432>)
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibrary.org/obo/CRO_0000019> "2018-09-14T20:26:00Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CRO_0000019> "software testing role")
-SubClassOf(<http://purl.obolibrary.org/obo/CRO_0000019> <http://purl.obolibrary.org/obo/CRO_0000028>)
+SubClassOf(<http://purl.obolibrary.org/obo/CRO_0000019> <http://purl.obolibrary.org/obo/CREDIT_00000009>)
 
 # Class: <http://purl.obolibrary.org/obo/CRO_0000020> (intellectual property advisor role)
 
@@ -274,16 +376,6 @@ AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> <http://purl.oboli
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibrary.org/obo/CRO_0000020> "2018-09-14T19:56:34Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CRO_0000020> "intellectual property advisor role")
 SubClassOf(<http://purl.obolibrary.org/obo/CRO_0000020> <http://purl.obolibrary.org/obo/CRO_0000078>)
-
-# Class: <http://purl.obolibrary.org/obo/CRO_0000021> (methodology role)
-
-AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/CRO_0000021> "Development or design of methodology; creation of models.")
-AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <http://purl.obolibrary.org/obo/CRO_0000021> "methodology development role")
-AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000119> <http://purl.obolibrary.org/obo/CRO_0000021> "http://dictionary.casrai.org/Contributor_Roles/Methodology")
-AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> <http://purl.obolibrary.org/obo/CRO_0000021> <http://orcid.org/0000-0001-5208-3432>)
-AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibrary.org/obo/CRO_0000021> "2018-09-14T20:04:19Z"^^xsd:dateTime)
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CRO_0000021> "methodology role")
-SubClassOf(<http://purl.obolibrary.org/obo/CRO_0000021> <http://purl.obolibrary.org/obo/CRO_00000000>)
 
 # Class: <http://purl.obolibrary.org/obo/CRO_0000022> (policy development role)
 
@@ -300,17 +392,6 @@ AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibra
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CRO_0000023> "preservation role")
 SubClassOf(<http://purl.obolibrary.org/obo/CRO_0000023> <http://purl.obolibrary.org/obo/CRO_00000000>)
 
-# Class: <http://purl.obolibrary.org/obo/CRO_0000024> (project management role)
-
-AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/CRO_0000024> "Management and coordination responsibility for the research activity planning and execution.")
-AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <http://purl.obolibrary.org/obo/CRO_0000024> "project administration role")
-AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <http://purl.obolibrary.org/obo/CRO_0000024> "project administrator role")
-AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000119> <http://purl.obolibrary.org/obo/CRO_0000024> "http://dictionary.casrai.org/Contributor_Roles/Project_administration")
-AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> <http://purl.obolibrary.org/obo/CRO_0000024> <http://orcid.org/0000-0001-5208-3432>)
-AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibrary.org/obo/CRO_0000024> "2018-09-14T20:04:49Z"^^xsd:dateTime)
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CRO_0000024> "project management role")
-SubClassOf(<http://purl.obolibrary.org/obo/CRO_0000024> <http://purl.obolibrary.org/obo/CRO_00000000>)
-
 # Class: <http://purl.obolibrary.org/obo/CRO_0000025> (regulatory administration role)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/CRO_0000025> "Manage regulatory and compliance issues for the research project.")
@@ -326,43 +407,6 @@ AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibra
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CRO_0000026> "research instrumentation role")
 SubClassOf(<http://purl.obolibrary.org/obo/CRO_0000026> <http://purl.obolibrary.org/obo/CRO_00000000>)
 
-# Class: <http://purl.obolibrary.org/obo/CRO_0000027> (resource provider role)
-
-AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/CRO_0000027> "Provision of study materials, reagents, materials, patients, laboratory samples, animals, instrumentation, computing resources, or other analysis tools.")
-AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000119> <http://purl.obolibrary.org/obo/CRO_0000027> "http://dictionary.casrai.org/Contributor_Roles/Resources")
-AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> <http://purl.obolibrary.org/obo/CRO_0000027> <http://orcid.org/0000-0001-5208-3432>)
-AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibrary.org/obo/CRO_0000027> "2018-09-14T20:06:06Z"^^xsd:dateTime)
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CRO_0000027> "resource provider role")
-SubClassOf(<http://purl.obolibrary.org/obo/CRO_0000027> <http://purl.obolibrary.org/obo/CRO_00000000>)
-
-# Class: <http://purl.obolibrary.org/obo/CRO_0000028> (software developer role)
-
-AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/CRO_0000028> "Programming, software development; designing computer programs; implementation of the computer code and supporting algorithms; testing of existing code components.")
-AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000119> <http://purl.obolibrary.org/obo/CRO_0000028> "http://dictionary.casrai.org/Contributor_Roles/Software")
-AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> <http://purl.obolibrary.org/obo/CRO_0000028> <http://orcid.org/0000-0001-5208-3432>)
-AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibrary.org/obo/CRO_0000028> "2018-09-14T20:06:12Z"^^xsd:dateTime)
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CRO_0000028> "software developer role")
-SubClassOf(<http://purl.obolibrary.org/obo/CRO_0000028> <http://purl.obolibrary.org/obo/CRO_00000000>)
-
-# Class: <http://purl.obolibrary.org/obo/CRO_0000029> (study investigation role)
-
-AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/CRO_0000029> "Conducting a research and investigation process, specifically performing the experiments, or data/evidence collection.")
-AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <http://purl.obolibrary.org/obo/CRO_0000029> "experimentation role")
-AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000119> <http://purl.obolibrary.org/obo/CRO_0000029> "http://dictionary.casrai.org/Contributor_Roles/Investigation")
-AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> <http://purl.obolibrary.org/obo/CRO_0000029> <http://orcid.org/0000-0001-5208-3432>)
-AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibrary.org/obo/CRO_0000029> "2018-09-14T20:06:17Z"^^xsd:dateTime)
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CRO_0000029> "study investigation role")
-SubClassOf(<http://purl.obolibrary.org/obo/CRO_0000029> <http://purl.obolibrary.org/obo/CRO_00000000>)
-
-# Class: <http://purl.obolibrary.org/obo/CRO_0000030> (supervision role)
-
-AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/CRO_0000030> "Oversight and leadership responsibility for the research activity planning and execution, including mentorship external to the core team.")
-AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000119> <http://purl.obolibrary.org/obo/CRO_0000030> "http://dictionary.casrai.org/Contributor_Roles/Supervision")
-AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> <http://purl.obolibrary.org/obo/CRO_0000030> <http://orcid.org/0000-0001-5208-3432>)
-AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibrary.org/obo/CRO_0000030> "2018-09-14T20:06:22Z"^^xsd:dateTime)
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CRO_0000030> "supervision role")
-SubClassOf(<http://purl.obolibrary.org/obo/CRO_0000030> <http://purl.obolibrary.org/obo/CRO_00000000>)
-
 # Class: <http://purl.obolibrary.org/obo/CRO_0000031> (team management role)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/CRO_0000031> "Coordination of diverse team members, often across different disciplines and locations.")
@@ -371,15 +415,6 @@ AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibra
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CRO_0000031> "team management role")
 SubClassOf(<http://purl.obolibrary.org/obo/CRO_0000031> <http://purl.obolibrary.org/obo/CRO_00000000>)
 
-# Class: <http://purl.obolibrary.org/obo/CRO_0000032> (validation role)
-
-AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/CRO_0000032> "Verification, whether as a part of the activity or separate, of the overall replication/reproducibility of results/experiments and other research outputs.")
-AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000119> <http://purl.obolibrary.org/obo/CRO_0000032> "http://dictionary.casrai.org/Contributor_Roles/Validation")
-AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> <http://purl.obolibrary.org/obo/CRO_0000032> <http://orcid.org/0000-0001-5208-3432>)
-AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibrary.org/obo/CRO_0000032> "2018-09-14T20:06:30Z"^^xsd:dateTime)
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CRO_0000032> "validation role")
-SubClassOf(<http://purl.obolibrary.org/obo/CRO_0000032> <http://purl.obolibrary.org/obo/CRO_00000000>)
-
 # Class: <http://purl.obolibrary.org/obo/CRO_0000033> (data aggregation role)
 
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> <http://purl.obolibrary.org/obo/CRO_0000033> <http://orcid.org/0000-0001-5208-3432>)
@@ -387,24 +422,13 @@ AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibra
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CRO_0000033> "data aggregation role")
 SubClassOf(<http://purl.obolibrary.org/obo/CRO_0000033> <http://purl.obolibrary.org/obo/CRO_0000015>)
 
-# Class: <http://purl.obolibrary.org/obo/CRO_0000034> (data analysis role)
-
-AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/CRO_0000034> "Preparation, creation and/or presentation of the published work, specifically visualization/data presentation.")
-AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <http://purl.obolibrary.org/obo/CRO_0000034> "formal analysis role")
-AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <http://purl.obolibrary.org/obo/CRO_0000034> "formal data analysis role")
-AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000119> <http://purl.obolibrary.org/obo/CRO_0000034> "http://dictionary.casrai.org/Contributor_Roles/Formal_analysis")
-AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> <http://purl.obolibrary.org/obo/CRO_0000034> <http://orcid.org/0000-0001-5208-3432>)
-AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibrary.org/obo/CRO_0000034> "2018-09-14T20:11:31Z"^^xsd:dateTime)
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CRO_0000034> "data analysis role")
-SubClassOf(<http://purl.obolibrary.org/obo/CRO_0000034> <http://purl.obolibrary.org/obo/CRO_0000015>)
-
 # Class: <http://purl.obolibrary.org/obo/CRO_0000035> (statistical data analysis role)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <http://purl.obolibrary.org/obo/CRO_0000035> "statistical analysis role")
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> <http://purl.obolibrary.org/obo/CRO_0000035> <http://orcid.org/0000-0001-5208-3432>)
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibrary.org/obo/CRO_0000035> "2018-09-14T20:11:35Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CRO_0000035> "statistical data analysis role")
-SubClassOf(<http://purl.obolibrary.org/obo/CRO_0000035> <http://purl.obolibrary.org/obo/CRO_0000034>)
+SubClassOf(<http://purl.obolibrary.org/obo/CRO_0000035> <http://purl.obolibrary.org/obo/CREDIT_00000003>)
 
 # Class: <http://purl.obolibrary.org/obo/CRO_0000036> (data collection role)
 
@@ -413,22 +437,12 @@ AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibra
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CRO_0000036> "data collection role")
 SubClassOf(<http://purl.obolibrary.org/obo/CRO_0000036> <http://purl.obolibrary.org/obo/CRO_0000015>)
 
-# Class: <http://purl.obolibrary.org/obo/CRO_0000037> (data curation role)
-
-AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/CRO_0000037> "Management activities to annotate (produce metadata), scrub data and maintain research data (including software code, where it is necessary for interpreting the data itself) for initial use and later re-use.")
-AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <http://purl.obolibrary.org/obo/CRO_0000037> "curation role")
-AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000119> <http://purl.obolibrary.org/obo/CRO_0000037> "http://dictionary.casrai.org/Contributor_Roles/Data_curation")
-AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> <http://purl.obolibrary.org/obo/CRO_0000037> <http://orcid.org/0000-0001-5208-3432>)
-AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibrary.org/obo/CRO_0000037> "2018-09-14T20:11:44Z"^^xsd:dateTime)
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CRO_0000037> "data curation role")
-SubClassOf(<http://purl.obolibrary.org/obo/CRO_0000037> <http://purl.obolibrary.org/obo/CRO_0000015>)
-
 # Class: <http://purl.obolibrary.org/obo/CRO_0000038> (metadata application role)
 
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> <http://purl.obolibrary.org/obo/CRO_0000038> <http://orcid.org/0000-0001-5208-3432>)
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibrary.org/obo/CRO_0000038> "2018-09-14T20:11:50Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CRO_0000038> "metadata application role")
-SubClassOf(<http://purl.obolibrary.org/obo/CRO_0000038> <http://purl.obolibrary.org/obo/CRO_0000037>)
+SubClassOf(<http://purl.obolibrary.org/obo/CRO_0000038> <http://purl.obolibrary.org/obo/CREDIT_00000002>)
 
 # Class: <http://purl.obolibrary.org/obo/CRO_0000039> (data entry role)
 
@@ -466,14 +480,6 @@ AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> <http://purl.oboli
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibrary.org/obo/CRO_0000043> "2018-09-14T20:12:25Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CRO_0000043> "data standards developer role")
 SubClassOf(<http://purl.obolibrary.org/obo/CRO_0000043> <http://purl.obolibrary.org/obo/CRO_0000015>)
-
-# Class: <http://purl.obolibrary.org/obo/CRO_0000044> (data visualization role)
-
-AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/CRO_0000044> "Preparation, creation and/or presentation of the published work, specifically visualization/data presentation.")
-AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> <http://purl.obolibrary.org/obo/CRO_0000044> <http://orcid.org/0000-0001-5208-3432>)
-AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibrary.org/obo/CRO_0000044> "2018-09-14T20:12:30Z"^^xsd:dateTime)
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CRO_0000044> "data visualization role")
-SubClassOf(<http://purl.obolibrary.org/obo/CRO_0000044> <http://purl.obolibrary.org/obo/CRO_0000015>)
 
 # Class: <http://purl.obolibrary.org/obo/CRO_0000045> (educational material development role)
 
@@ -534,7 +540,7 @@ AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <http://purl.ob
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> <http://purl.obolibrary.org/obo/CRO_0000052> <http://orcid.org/0000-0001-5208-3432>)
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibrary.org/obo/CRO_0000052> "2018-09-14T20:19:52Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CRO_0000052> "guideline development role")
-SubClassOf(<http://purl.obolibrary.org/obo/CRO_0000052> <http://purl.obolibrary.org/obo/CRO_0000021>)
+SubClassOf(<http://purl.obolibrary.org/obo/CRO_0000052> <http://purl.obolibrary.org/obo/CREDIT_00000006>)
 
 # Class: <http://purl.obolibrary.org/obo/CRO_0000053> (protocol creation role)
 
@@ -542,14 +548,14 @@ AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <http://purl.ob
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> <http://purl.obolibrary.org/obo/CRO_0000053> <http://orcid.org/0000-0001-5208-3432>)
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibrary.org/obo/CRO_0000053> "2018-09-14T20:19:56Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CRO_0000053> "protocol creation role")
-SubClassOf(<http://purl.obolibrary.org/obo/CRO_0000053> <http://purl.obolibrary.org/obo/CRO_0000021>)
+SubClassOf(<http://purl.obolibrary.org/obo/CRO_0000053> <http://purl.obolibrary.org/obo/CREDIT_00000006>)
 
 # Class: <http://purl.obolibrary.org/obo/CRO_0000054> (standard operating procedure development role)
 
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> <http://purl.obolibrary.org/obo/CRO_0000054> <http://orcid.org/0000-0001-5208-3432>)
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibrary.org/obo/CRO_0000054> "2018-09-14T20:20:02Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CRO_0000054> "standard operating procedure development role")
-SubClassOf(<http://purl.obolibrary.org/obo/CRO_0000054> <http://purl.obolibrary.org/obo/CRO_0000021>)
+SubClassOf(<http://purl.obolibrary.org/obo/CRO_0000054> <http://purl.obolibrary.org/obo/CREDIT_00000006>)
 
 # Class: <http://purl.obolibrary.org/obo/CRO_0000055> (study design role)
 
@@ -557,14 +563,14 @@ AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.ob
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> <http://purl.obolibrary.org/obo/CRO_0000055> <http://orcid.org/0000-0001-5208-3432>)
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibrary.org/obo/CRO_0000055> "2018-09-14T20:20:06Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CRO_0000055> "study design role")
-SubClassOf(<http://purl.obolibrary.org/obo/CRO_0000055> <http://purl.obolibrary.org/obo/CRO_0000021>)
+SubClassOf(<http://purl.obolibrary.org/obo/CRO_0000055> <http://purl.obolibrary.org/obo/CREDIT_00000006>)
 
 # Class: <http://purl.obolibrary.org/obo/CRO_0000056> (technique development role)
 
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> <http://purl.obolibrary.org/obo/CRO_0000056> <http://orcid.org/0000-0001-5208-3432>)
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibrary.org/obo/CRO_0000056> "2018-09-14T20:20:11Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CRO_0000056> "technique development role")
-SubClassOf(<http://purl.obolibrary.org/obo/CRO_0000056> <http://purl.obolibrary.org/obo/CRO_0000021>)
+SubClassOf(<http://purl.obolibrary.org/obo/CRO_0000056> <http://purl.obolibrary.org/obo/CREDIT_00000006>)
 
 # Class: <http://purl.obolibrary.org/obo/CRO_0000057> (device development role)
 
@@ -596,7 +602,7 @@ AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <http://purl.ob
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> <http://purl.obolibrary.org/obo/CRO_0000060> <http://orcid.org/0000-0001-5208-3432>)
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibrary.org/obo/CRO_0000060> "2018-09-14T20:25:30Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CRO_0000060> "code review role")
-SubClassOf(<http://purl.obolibrary.org/obo/CRO_0000060> <http://purl.obolibrary.org/obo/CRO_0000028>)
+SubClassOf(<http://purl.obolibrary.org/obo/CRO_0000060> <http://purl.obolibrary.org/obo/CREDIT_00000009>)
 
 # Class: <http://purl.obolibrary.org/obo/CRO_0000061> (computer programming role)
 
@@ -604,7 +610,7 @@ AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.ob
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> <http://purl.obolibrary.org/obo/CRO_0000061> <http://orcid.org/0000-0001-5208-3432>)
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibrary.org/obo/CRO_0000061> "2018-09-14T20:25:35Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CRO_0000061> "computer programming role")
-SubClassOf(<http://purl.obolibrary.org/obo/CRO_0000061> <http://purl.obolibrary.org/obo/CRO_0000028>)
+SubClassOf(<http://purl.obolibrary.org/obo/CRO_0000061> <http://purl.obolibrary.org/obo/CREDIT_00000009>)
 
 # Class: <http://purl.obolibrary.org/obo/CRO_0000062> (software architecture role)
 
@@ -612,7 +618,7 @@ AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.ob
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> <http://purl.obolibrary.org/obo/CRO_0000062> <http://orcid.org/0000-0001-5208-3432>)
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibrary.org/obo/CRO_0000062> "2018-09-14T20:25:40Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CRO_0000062> "software architecture role")
-SubClassOf(<http://purl.obolibrary.org/obo/CRO_0000062> <http://purl.obolibrary.org/obo/CRO_0000028>)
+SubClassOf(<http://purl.obolibrary.org/obo/CRO_0000062> <http://purl.obolibrary.org/obo/CREDIT_00000009>)
 
 # Class: <http://purl.obolibrary.org/obo/CRO_0000063> (software design role)
 
@@ -620,7 +626,7 @@ AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.ob
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> <http://purl.obolibrary.org/obo/CRO_0000063> <http://orcid.org/0000-0001-5208-3432>)
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibrary.org/obo/CRO_0000063> "2018-09-14T20:25:45Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CRO_0000063> "software design role")
-SubClassOf(<http://purl.obolibrary.org/obo/CRO_0000063> <http://purl.obolibrary.org/obo/CRO_0000028>)
+SubClassOf(<http://purl.obolibrary.org/obo/CRO_0000063> <http://purl.obolibrary.org/obo/CREDIT_00000009>)
 
 # Class: <http://purl.obolibrary.org/obo/CRO_0000064> (software engineering role)
 
@@ -628,7 +634,7 @@ AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.ob
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> <http://purl.obolibrary.org/obo/CRO_0000064> <http://orcid.org/0000-0001-5208-3432>)
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibrary.org/obo/CRO_0000064> "2018-09-14T20:25:49Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CRO_0000064> "software engineering role")
-SubClassOf(<http://purl.obolibrary.org/obo/CRO_0000064> <http://purl.obolibrary.org/obo/CRO_0000028>)
+SubClassOf(<http://purl.obolibrary.org/obo/CRO_0000064> <http://purl.obolibrary.org/obo/CREDIT_00000009>)
 
 # Class: <http://purl.obolibrary.org/obo/CRO_0000065> (software project management role)
 
@@ -636,7 +642,7 @@ AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.ob
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> <http://purl.obolibrary.org/obo/CRO_0000065> <http://orcid.org/0000-0001-5208-3432>)
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibrary.org/obo/CRO_0000065> "2018-09-14T20:25:55Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CRO_0000065> "software project management role")
-SubClassOf(<http://purl.obolibrary.org/obo/CRO_0000065> <http://purl.obolibrary.org/obo/CRO_0000028>)
+SubClassOf(<http://purl.obolibrary.org/obo/CRO_0000065> <http://purl.obolibrary.org/obo/CREDIT_00000009>)
 
 # Class: <http://purl.obolibrary.org/obo/CRO_0000067> (archivist role)
 
@@ -784,14 +790,14 @@ AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <http://purl.ob
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> <http://purl.obolibrary.org/obo/CRO_0000086> <http://orcid.org/0000-0001-5208-3432>)
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibrary.org/obo/CRO_0000086> "2018-10-01T20:57:53Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CRO_0000086> "research conceptualization role")
-SubClassOf(<http://purl.obolibrary.org/obo/CRO_0000086> <http://purl.obolibrary.org/obo/CRO_0000013>)
+SubClassOf(<http://purl.obolibrary.org/obo/CRO_0000086> <http://purl.obolibrary.org/obo/CREDIT_00000001>)
 
 # Class: <http://purl.obolibrary.org/obo/CRO_0000087> (research technician role)
 
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> <http://purl.obolibrary.org/obo/CRO_0000087> <http://orcid.org/0000-0001-5208-3432>)
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibrary.org/obo/CRO_0000087> "2018-10-01T20:58:59Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CRO_0000087> "research technician role")
-SubClassOf(<http://purl.obolibrary.org/obo/CRO_0000087> <http://purl.obolibrary.org/obo/CRO_0000029>)
+SubClassOf(<http://purl.obolibrary.org/obo/CRO_0000087> <http://purl.obolibrary.org/obo/CREDIT_00000005>)
 
 # Class: <http://purl.obolibrary.org/obo/CRO_0000088> (original draft preparation role)
 

--- a/src/ontology/cro-edit.owl
+++ b/src/ontology/cro-edit.owl
@@ -235,15 +235,15 @@ AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibra
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CREDIT_00000013> "writing original draft role")
 SubClassOf(<http://purl.obolibrary.org/obo/CREDIT_00000013> <http://purl.obolibrary.org/obo/CRO_0000001>)
 
-# Class: <http://purl.obolibrary.org/obo/CREDIT_00000014> (editing and proofreading role)
+# Class: <http://purl.obolibrary.org/obo/CREDIT_00000014> (writing review and editing role)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/CREDIT_00000014> "Preparation, creation and/or presentation of the published work by those from the original research group, specifically critical review, commentary or revision – including pre- or post-publication stages.")
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <http://purl.obolibrary.org/obo/CREDIT_00000014> "editing and proofreading role")
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <http://purl.obolibrary.org/obo/CREDIT_00000014> "review and editing")
-AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <http://purl.obolibrary.org/obo/CREDIT_00000014> "writing review and editing role")
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000119> <http://purl.obolibrary.org/obo/CREDIT_00000014> "http://dictionary.casrai.org/Contributor_Roles/Writing_%E2%80%93_review_%26_editing")
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> <http://purl.obolibrary.org/obo/CREDIT_00000014> <http://orcid.org/0000-0001-5208-3432>)
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibrary.org/obo/CREDIT_00000014> "2018-09-14T19:48:16Z"^^xsd:dateTime)
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CREDIT_00000014> "editing and proofreading role")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CREDIT_00000014> "writing review and editing role")
 SubClassOf(<http://purl.obolibrary.org/obo/CREDIT_00000014> <http://purl.obolibrary.org/obo/CRO_0000001>)
 
 # Class: <http://purl.obolibrary.org/obo/CRO_00000000> (contributor role)

--- a/src/ontology/cro-edit.owl
+++ b/src/ontology/cro-edit.owl
@@ -217,13 +217,13 @@ AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibra
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CREDIT_00000011> "validation role")
 SubClassOf(<http://purl.obolibrary.org/obo/CREDIT_00000011> <http://purl.obolibrary.org/obo/CRO_00000000>)
 
-# Class: <http://purl.obolibrary.org/obo/CREDIT_00000012> (data visualization role)
+# Class: <http://purl.obolibrary.org/obo/CREDIT_00000012> (visualization role)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/CREDIT_00000012> "Preparation, creation and/or presentation of the published work, specifically visualization/data presentation.")
-AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <http://purl.obolibrary.org/obo/CREDIT_00000012> "visualization role")
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <http://purl.obolibrary.org/obo/CREDIT_00000012> "data visualization role")
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> <http://purl.obolibrary.org/obo/CREDIT_00000012> <http://orcid.org/0000-0001-5208-3432>)
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibrary.org/obo/CREDIT_00000012> "2018-09-14T20:12:30Z"^^xsd:dateTime)
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CREDIT_00000012> "data visualization role")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CREDIT_00000012> "visualization role")
 SubClassOf(<http://purl.obolibrary.org/obo/CREDIT_00000012> <http://purl.obolibrary.org/obo/CRO_0000015>)
 
 # Class: <http://purl.obolibrary.org/obo/CREDIT_00000013> (writing original draft role)

--- a/src/ontology/cro-edit.owl
+++ b/src/ontology/cro-edit.owl
@@ -147,15 +147,15 @@ AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibra
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CREDIT_00000004> "funding acquisition role")
 SubClassOf(<http://purl.obolibrary.org/obo/CREDIT_00000004> <http://purl.obolibrary.org/obo/CRO_00000000>)
 
-# Class: <http://purl.obolibrary.org/obo/CREDIT_00000005> (study investigation role)
+# Class: <http://purl.obolibrary.org/obo/CREDIT_00000005> (investigation role)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/CREDIT_00000005> "Conducting a research and investigation process, specifically performing the experiments, or data/evidence collection.")
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <http://purl.obolibrary.org/obo/CREDIT_00000005> "experimentation role")
-AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <http://purl.obolibrary.org/obo/CREDIT_00000005> "investigation role")
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <http://purl.obolibrary.org/obo/CREDIT_00000005> "study investigation role")
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000119> <http://purl.obolibrary.org/obo/CREDIT_00000005> "http://dictionary.casrai.org/Contributor_Roles/Investigation")
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> <http://purl.obolibrary.org/obo/CREDIT_00000005> <http://orcid.org/0000-0001-5208-3432>)
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibrary.org/obo/CREDIT_00000005> "2018-09-14T20:06:17Z"^^xsd:dateTime)
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CREDIT_00000005> "study investigation role")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CREDIT_00000005> "investigation role")
 SubClassOf(<http://purl.obolibrary.org/obo/CREDIT_00000005> <http://purl.obolibrary.org/obo/CRO_00000000>)
 
 # Class: <http://purl.obolibrary.org/obo/CREDIT_00000006> (methodology role)

--- a/src/ontology/cro-edit.owl
+++ b/src/ontology/cro-edit.owl
@@ -7,8 +7,8 @@ Prefix(rdfs:=<http://www.w3.org/2000/01/rdf-schema#>)
 
 
 Ontology(<http://purl.obolibrary.org/obo/cro.owl>
-Import(<http://purl.obolibrary.org/obo/cro/imports/bfo_import.owl>)
 Import(<http://purl.obolibrary.org/obo/cro/imports/iao_import.owl>)
+Import(<http://purl.obolibrary.org/obo/cro/imports/bfo_import.owl>)
 Annotation(rdfs:comment "Contributor Role Ontology")
 
 Declaration(Class(<http://purl.obolibrary.org/obo/CREDIT_00000001>))
@@ -128,15 +128,15 @@ AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibra
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CREDIT_00000002> "data curation role")
 SubClassOf(<http://purl.obolibrary.org/obo/CREDIT_00000002> <http://purl.obolibrary.org/obo/CRO_0000015>)
 
-# Class: <http://purl.obolibrary.org/obo/CREDIT_00000003> (data analysis role)
+# Class: <http://purl.obolibrary.org/obo/CREDIT_00000003> (formal analysis role)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/CREDIT_00000003> "Preparation, creation and/or presentation of the published work, specifically visualization/data presentation.")
-AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <http://purl.obolibrary.org/obo/CREDIT_00000003> "formal analysis role")
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <http://purl.obolibrary.org/obo/CREDIT_00000003> "data analysis role")
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <http://purl.obolibrary.org/obo/CREDIT_00000003> "formal data analysis role")
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000119> <http://purl.obolibrary.org/obo/CREDIT_00000003> "http://dictionary.casrai.org/Contributor_Roles/Formal_analysis")
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> <http://purl.obolibrary.org/obo/CREDIT_00000003> <http://orcid.org/0000-0001-5208-3432>)
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibrary.org/obo/CREDIT_00000003> "2018-09-14T20:11:31Z"^^xsd:dateTime)
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CREDIT_00000003> "data analysis role")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CREDIT_00000003> "formal analysis role")
 SubClassOf(<http://purl.obolibrary.org/obo/CREDIT_00000003> <http://purl.obolibrary.org/obo/CRO_0000015>)
 
 # Class: <http://purl.obolibrary.org/obo/CREDIT_00000004> (funding acquisition role)

--- a/src/ontology/cro-edit.owl
+++ b/src/ontology/cro-edit.owl
@@ -189,14 +189,14 @@ AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibra
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CREDIT_00000008> "resources role")
 SubClassOf(<http://purl.obolibrary.org/obo/CREDIT_00000008> <http://purl.obolibrary.org/obo/CRO_00000000>)
 
-# Class: <http://purl.obolibrary.org/obo/CREDIT_00000009> (software developer role)
+# Class: <http://purl.obolibrary.org/obo/CREDIT_00000009> (software role)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/CREDIT_00000009> "Programming, software development; designing computer programs; implementation of the computer code and supporting algorithms; testing of existing code components.")
-AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <http://purl.obolibrary.org/obo/CREDIT_00000009> "software role")
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <http://purl.obolibrary.org/obo/CREDIT_00000009> "software developer role")
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000119> <http://purl.obolibrary.org/obo/CREDIT_00000009> "http://dictionary.casrai.org/Contributor_Roles/Software")
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> <http://purl.obolibrary.org/obo/CREDIT_00000009> <http://orcid.org/0000-0001-5208-3432>)
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibrary.org/obo/CREDIT_00000009> "2018-09-14T20:06:12Z"^^xsd:dateTime)
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CREDIT_00000009> "software developer role")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CREDIT_00000009> "software role")
 SubClassOf(<http://purl.obolibrary.org/obo/CREDIT_00000009> <http://purl.obolibrary.org/obo/CRO_00000000>)
 
 # Class: <http://purl.obolibrary.org/obo/CREDIT_00000010> (supervision role)

--- a/src/ontology/cro-edit.owl
+++ b/src/ontology/cro-edit.owl
@@ -168,15 +168,15 @@ AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibra
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CREDIT_00000006> "methodology role")
 SubClassOf(<http://purl.obolibrary.org/obo/CREDIT_00000006> <http://purl.obolibrary.org/obo/CRO_00000000>)
 
-# Class: <http://purl.obolibrary.org/obo/CREDIT_00000007> (project management role)
+# Class: <http://purl.obolibrary.org/obo/CREDIT_00000007> (project administration role)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/CREDIT_00000007> "Management and coordination responsibility for the research activity planning and execution.")
-AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <http://purl.obolibrary.org/obo/CREDIT_00000007> "project administration role")
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <http://purl.obolibrary.org/obo/CREDIT_00000007> "project administrator role")
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <http://purl.obolibrary.org/obo/CREDIT_00000007> "project management role")
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000119> <http://purl.obolibrary.org/obo/CREDIT_00000007> "http://dictionary.casrai.org/Contributor_Roles/Project_administration")
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> <http://purl.obolibrary.org/obo/CREDIT_00000007> <http://orcid.org/0000-0001-5208-3432>)
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibrary.org/obo/CREDIT_00000007> "2018-09-14T20:04:49Z"^^xsd:dateTime)
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CREDIT_00000007> "project management role")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CREDIT_00000007> "project administration role")
 SubClassOf(<http://purl.obolibrary.org/obo/CREDIT_00000007> <http://purl.obolibrary.org/obo/CRO_00000000>)
 
 # Class: <http://purl.obolibrary.org/obo/CREDIT_00000008> (resource provider role)


### PR DESCRIPTION
@marijane - Kristi Holmes wanted us to import/reuse terms from the Credit Ontology in CRO, so I just replaced the IRIs for the terms in CRO with the IDs from the Credit Ontology. I did this on a branch in case you didn't like this approach (although I did make a couple changes on master for the terms:
CREDIT_00000014 'editing and proofreading role'
CREDIT_00000013 'writing original draft role'

Let me know if there are any issues with this approach. Thanks!

