### PR TITLE
Remove 'credit' from IMPORTS definition

### DIFF
--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -57,7 +57,7 @@ $(ONT).obo: $(ONT).owl
 # These live in the imports/ folder
 # These can be regenerated with make all_imports
 
-IMPORTS = bfo iao credit
+IMPORTS = bfo iao
 IMPORTS_OWL = $(patsubst %, imports/%_import.owl,$(IMPORTS)) $(patsubst %, imports/%_import.obo,$(IMPORTS)) $(patsubst %, imports/%_terms.txt,$(IMPORTS))
 
 # generate seed with all referenced entities


### PR DESCRIPTION
The ODK assumes imported ontologies are OBO ontologies
Which means it tries to import CRediT from http://purl.obolibrary.org/obo
instead of http://purl.org/credit/ontology#
This makes the build fail in Travis CI.
This commit is an experiment to see if we can work around this problem.